### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,7 @@ svgtune (0.3.1-2) UNRELEASED; urgency=medium
   * Update standards version to 4.6.1, no changes needed.
   * Set upstream metadata fields: Repository.
   * Update standards version to 4.6.2, no changes needed.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ svgtune (0.3.1-2) UNRELEASED; urgency=medium
   * Use versioned copyright format URI.
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Repository-Browse.
+  * Use secure URI in Vcs control headers: Vcs-Browser, Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ svgtune (0.3.1-2) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Repository-Browse.
   * Use secure URI in Vcs control headers: Vcs-Browser, Vcs-Git.
   * Update standards version to 4.6.1, no changes needed.
+  * Set upstream metadata fields: Repository.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 svgtune (0.3.1-2) UNRELEASED; urgency=medium
 
   * Use versioned copyright format URI.
+  * Use secure URI in Homepage field.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+svgtune (0.3.1-2) UNRELEASED; urgency=medium
+
+  * Use versioned copyright format URI.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
+
 svgtune (0.3.1-1) unstable; urgency=medium
 
   * Fresh upstream release with python3 fixes

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ svgtune (0.3.1-2) UNRELEASED; urgency=medium
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Repository-Browse.
   * Use secure URI in Vcs control headers: Vcs-Browser, Vcs-Git.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ svgtune (0.3.1-2) UNRELEASED; urgency=medium
   * Use secure URI in Vcs control headers: Vcs-Browser, Vcs-Git.
   * Update standards version to 4.6.1, no changes needed.
   * Set upstream metadata fields: Repository.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ svgtune (0.3.1-2) UNRELEASED; urgency=medium
 
   * Use versioned copyright format URI.
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Thu, 20 Oct 2022 06:32:27 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Yaroslav Halchenko <debian@onerussian.com>
 Build-Depends: cdbs, debhelper (>= 10), help2man, python3, python3-lxml
 Standards-Version: 4.5.0
-Homepage: http://github.com/yarikoptic/svgtune
+Homepage: https://github.com/yarikoptic/svgtune
 Vcs-Git: git://github.com/yarikoptic/svgtune.git -b debian
 Vcs-Browser: http://github.com/yarikoptic/svgtune
 

--- a/debian/control
+++ b/debian/control
@@ -5,8 +5,8 @@ Maintainer: Yaroslav Halchenko <debian@onerussian.com>
 Build-Depends: cdbs, debhelper (>= 10), help2man, python3, python3-lxml
 Standards-Version: 4.5.0
 Homepage: https://github.com/yarikoptic/svgtune
-Vcs-Git: git://github.com/yarikoptic/svgtune.git -b debian
-Vcs-Browser: http://github.com/yarikoptic/svgtune
+Vcs-Git: https://github.com/yarikoptic/svgtune.git -b debian
+Vcs-Browser: https://github.com/yarikoptic/svgtune
 
 
 Package: svgtune

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: graphics
 Priority: optional
 Maintainer: Yaroslav Halchenko <debian@onerussian.com>
 Build-Depends: cdbs, debhelper (>= 10), help2man, python3, python3-lxml
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Homepage: https://github.com/yarikoptic/svgtune
 Vcs-Git: https://github.com/yarikoptic/svgtune.git -b debian
 Vcs-Browser: https://github.com/yarikoptic/svgtune

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: graphics
 Priority: optional
 Maintainer: Yaroslav Halchenko <debian@onerussian.com>
 Build-Depends: cdbs, debhelper (>= 10), help2man, python3, python3-lxml
-Standards-Version: 4.5.0
+Standards-Version: 4.6.1
 Homepage: https://github.com/yarikoptic/svgtune
 Vcs-Git: https://github.com/yarikoptic/svgtune.git -b debian
 Vcs-Browser: https://github.com/yarikoptic/svgtune

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format-Specification: http://svn.debian.org/wsvn/dep/web/deps/dep5.mdwn?op=file&rev=135
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Name: svgtune
 Maintainer: Yaroslav Halchenko <debian@onerussian.com>
 Upstream-Source-Location: http://github.com/yarikoptic/svgtune

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,2 +1,3 @@
 ---
+Repository: https://github.com/yarikoptic/svgtune.git
 Repository-Browse: https://github.com/yarikoptic/svgtune

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,2 @@
+---
+Repository-Browse: https://github.com/yarikoptic/svgtune

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,3 +1,5 @@
 ---
+Bug-Database: https://github.com/yarikoptic/svgtune/issues
+Bug-Submit: https://github.com/yarikoptic/svgtune/issues/new
 Repository: https://github.com/yarikoptic/svgtune.git
 Repository-Browse: https://github.com/yarikoptic/svgtune


### PR DESCRIPTION
Fix some issues reported by lintian

* Use versioned copyright format URI. ([unversioned-copyright-format-uri](https://lintian.debian.org/tags/unversioned-copyright-format-uri))
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri))
* Set upstream metadata fields: Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing))
* Use secure URI in Vcs control headers: Vcs-Browser, Vcs-Git. ([vcs-field-uses-insecure-uri](https://lintian.debian.org/tags/vcs-field-uses-insecure-uri))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Set upstream metadata fields: Repository. ([upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))

## Debdiff

These changes affect the binary packages:

File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Homepage: [-http&#8203;://github.com/yarikoptic/svgtune-] {+https&#8203;://github.com/yarikoptic/svgtune+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/ef43ca5d-3378-4495-8ec0-4d6fec9397b8/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/ef43ca5d-3378-4495-8ec0-4d6fec9397b8/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/ef43ca5d-3378-4495-8ec0-4d6fec9397b8.